### PR TITLE
Add Dockerfile to project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.14-alpine as builder
+
+WORKDIR /app
+
+COPY  go.mod ./
+
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o fuego-cache -ldflags="-s -w" cmd/main.go
+
+# Stage for the application
+FROM alpine:latest
+
+WORKDIR /app
+
+COPY --from=builder /app/fuego-cache /app/config.json /app/
+
+EXPOSE 9919
+EXPOSE 9999
+
+CMD /app/fuego-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine as builder
+FROM golang:1.16-alpine as builder
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ GOFMT=$(GOCMD)fmt
 MAIN= cmd/main.go
 BINARY_NAME=fuego-cache
 
+
 all: test build
 
 build:
@@ -26,3 +27,15 @@ fmt:
 # Cross compilation
 build-linux:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(BINARY_NAME) -v
+
+docker-build-cli:
+	@docker build -t fuego-cache-cli .
+
+docker-build-http:
+	@docker build -t fuego-cache-http .
+
+docker-run-cli:
+	@docker run -it -p 9919:9919 fuego-cache-cli
+
+docker-run-http:
+	@docker run -d -p 9999:9999 fuego-cache-http

--- a/README.md
+++ b/README.md
@@ -18,8 +18,20 @@ No further installation needed, just `go get github.com/tomiok/fuego-cache`
 `make run`
 
 ### Docker
-SID
+#### Build CLI
+`make docker-build-cli`
 
+#### Build HTTP
+`make docker-build-http`
+
+#### Run CLI Mode
+make docker-run-cli
+
+#### Run HTTP Mode
+make docker-run-http
+
+**_NOTE:_**
+Since configuration changes from a json file you need to build different images based on your configuration 
 
 ### TEST
 this is a test


### PR DESCRIPTION
A simple Dockerfile exposing both TCP and HTTP ports to use as needed, since configuration is managed with a JSON file any change to it will need a rebuild of the image. 